### PR TITLE
Stitch Plate Wells into pyramid

### DIFF
--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -356,13 +356,15 @@ class Plate(Spec):
         stitched full-resolution images.
         """
         self.plate_data = self.lookup("plate", {})
-        print('self.plate_data', self.plate_data)
+        print("self.plate_data", self.plate_data)
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
 
         # FIXME: shouldn't hard code
         self.acquisitions = ["0"]
-        self.fields = ["Field_1",]
+        self.fields = [
+            "Field_1",
+        ]
         self.row_labels = ascii_uppercase[0 : self.rows]
         self.col_labels = range(1, self.cols + 1)
 
@@ -398,7 +400,7 @@ class Plate(Spec):
             longest_side = longest_side // 2
             target_level += 1
 
-        print('target_level', target_level)
+        print("target_level", target_level)
         # Assume this matches the sizes of the downsampled images in each field
         # Probably better to look it up - Assumed to be same for every image
         tile_sizes = []
@@ -443,7 +445,7 @@ class Plate(Spec):
         # for level in range(5):
 
         for level in [target_level]:
-            print('level', level)
+            print("level", level)
             t_stacks = []
             for t in range(size_t):
                 c_stacks = []
@@ -465,14 +467,7 @@ class Plate(Spec):
         # Use the first image's metadata for viewing the whole Plate
         node.metadata = image_node.metadata
 
-        node.metadata.update({
-            "metadata": {
-                "plate": {
-                    "rows": rows,
-                    "columns": cols,
-                }
-            }
-        })
+        node.metadata.update({"metadata": {"plate": {"rows": rows, "columns": cols,}}})
 
 
 class Reader:

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -349,6 +349,7 @@ class Plate(Spec):
     def __init__(self, node: Node) -> None:
         super().__init__(node)
         # TODO: start checking metadata version
+<<<<<<< HEAD
         self.plate_data = self.lookup("plate", {})
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
@@ -358,6 +359,8 @@ class Plate(Spec):
         self.fields = ["Field_1", "Field_2", "Field_3", "Field_4"]
         self.row_labels = ascii_uppercase[0 : self.rows]
         self.col_labels = range(1, self.cols + 1)
+=======
+>>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
 
         self.get_pyramid_lazy(node)
 
@@ -366,14 +369,29 @@ class Plate(Spec):
         Return a pyramid of dask data, where the highest resolution is the
         stitched full-resolution images.
         """
+        self.plate_data = self.lookup("plate", {})
+        print('self.plate_data', self.plate_data)
+        self.rows = self.plate_data.get("rows", 0)
+        self.cols = self.plate_data.get("columns", 0)
 
+<<<<<<< HEAD
         run = "0"
+=======
+        # FIXME: shouldn't hard code
+        self.acquisitions = ["0"]
+        self.fields = ["Field_1",]
+        self.row_labels = ascii_uppercase[0 : self.rows]
+        self.col_labels = range(1, self.cols + 1)
+
+        # TODO: support more Acquisitions - just 1st for now
+        run = self.acquisitions[0]
+>>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
         rows = self.rows
         cols = self.cols
         row_labels = self.row_labels
 
         # Get the first image...
-        path = f"{run}/A/1/Field_1"
+        path = f"{run}/{row_labels[0]}/{self.col_labels[0]}/{self.fields[0]}"
         image_zarr = self.zarr.create(path)
         image_node = Node(image_zarr, node)
 
@@ -386,6 +404,19 @@ class Plate(Spec):
 
         size_x = img_shape[3]
         size_y = img_shape[4]
+
+        # FIXME - if only returning a single stiched plate (not a pyramid)
+        # need to decide optimal size. E.g. longest side < 3000
+        TARGET_SIZE = 3000
+        plate_width = cols * size_x
+        plate_height = cols * size_y
+        longest_side = max(plate_width, plate_height)
+        target_level = 0
+        while longest_side > TARGET_SIZE:
+            longest_side = longest_side // 2
+            target_level += 1
+
+        print('target_level', target_level)
         # Assume this matches the sizes of the downsampled images in each field
         # Probably better to look it up - Assumed to be same for every image
         tile_sizes = []
@@ -428,8 +459,9 @@ class Plate(Spec):
 
         # This should create a pyramid of levels, but causes seg faults!
         # for level in range(5):
-        for level in [0]:
-            print("level", level)
+
+        for level in [target_level]:
+            print('level', level)
             t_stacks = []
             for t in range(size_t):
                 c_stacks = []

--- a/ome_zarr/reader.py
+++ b/ome_zarr/reader.py
@@ -348,20 +348,6 @@ class Plate(Spec):
 
     def __init__(self, node: Node) -> None:
         super().__init__(node)
-        # TODO: start checking metadata version
-<<<<<<< HEAD
-        self.plate_data = self.lookup("plate", {})
-        self.rows = self.plate_data.get("rows", 0)
-        self.cols = self.plate_data.get("columns", 0)
-
-        # FIXME: shouldn't hard code
-        self.acquisitions = ["PlateAcquisition Name 0", "0"]
-        self.fields = ["Field_1", "Field_2", "Field_3", "Field_4"]
-        self.row_labels = ascii_uppercase[0 : self.rows]
-        self.col_labels = range(1, self.cols + 1)
-=======
->>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
-
         self.get_pyramid_lazy(node)
 
     def get_pyramid_lazy(self, node: Node) -> None:
@@ -374,9 +360,6 @@ class Plate(Spec):
         self.rows = self.plate_data.get("rows", 0)
         self.cols = self.plate_data.get("columns", 0)
 
-<<<<<<< HEAD
-        run = "0"
-=======
         # FIXME: shouldn't hard code
         self.acquisitions = ["0"]
         self.fields = ["Field_1",]
@@ -385,7 +368,6 @@ class Plate(Spec):
 
         # TODO: support more Acquisitions - just 1st for now
         run = self.acquisitions[0]
->>>>>>> f316d76... Calculate optimal resolution level so stitched plate < 3000 pixels
         rows = self.rows
         cols = self.cols
         row_labels = self.row_labels
@@ -482,16 +464,15 @@ class Plate(Spec):
         node.data = pyramid
         # Use the first image's metadata for viewing the whole Plate
         node.metadata = image_node.metadata
-        visibility = True
-        for acq in self.acquisitions:
-            for row in self.row_labels:
-                for col in self.col_labels:
-                    for field in self.fields:
-                        path = f"{acq}/{row}/{col}/{field}"
-                        child_zarr = self.zarr.create(path)
-                        if child_zarr.exists():
-                            node.add(child_zarr, visibility=visibility)
-                            visibility = False
+
+        node.metadata.update({
+            "metadata": {
+                "plate": {
+                    "rows": rows,
+                    "columns": cols,
+                }
+            }
+        })
 
 
 class Reader:


### PR DESCRIPTION
@joshmoore I have tried to re-use some of the logic from https://github.com/tlambert03/napari-omero/pull/1 to create a 'dask.delayed' Plate pyramid by stitching the Images and their sub-resolution levels together.

However, it's not quite working 😞 

It seems that all the tiles are requested immediately, instead of waiting for napari to request each zoom level/tile.
So, using anything other than a single level in the pyramid causes a seg-fault!

However, even stitching together all the full-sized images works OK for a local copy of idr0002 (single T and Z, 2 channels):

<img width="1075" alt="Screenshot 2020-10-21 at 21 16 31" src="https://user-images.githubusercontent.com/900055/96783299-62259200-13e5-11eb-8f0e-8cb4ab5f7939.png">
